### PR TITLE
Add support for Canon network printing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
 	hpijs-ppds \
 	hp-ppd \
 	python-cups \
+	cups-backend-bjnp \
 && rm -rf /var/lib/apt/lists/*
 
 # This will use port 631


### PR DESCRIPTION
Some canon printers use a propritary network prototcol (bjnp) to print over the network. This pull request adds support in cups for this protocol to allow printing directly to the printer over the network. I have tested using a Canon MP640 but I believe this protocol is used by a wide range of Canon printers.